### PR TITLE
Fix for Export Package request that was not working due to wrong content-type

### DIFF
--- a/cloudshell/rest/api.py
+++ b/cloudshell/rest/api.py
@@ -132,8 +132,9 @@ class PackagingRestApiClient(object):
         url = "http://{0.ip}:{0.port}/API/Package/ExportPackage".format(self)
         response = post(
             url,
-            headers={"Authorization": "Basic " + self.token},
-            data={"TopologyNames": topologies},
+            headers={"Authorization": "Basic " + self.token,
+                     "Content-type": "application/json"},
+            json={"TopologyNames": topologies},
         )
 
         if response.status_code in (404, 405):

--- a/tests/test_packaging_rest_api_client.py
+++ b/tests/test_packaging_rest_api_client.py
@@ -309,8 +309,9 @@ class TestPackagingRestApiClient(fake_filesystem_unittest.TestCase):
         # verify
         mock_post.assert_called_once_with(
             'http://SERVER:9000/API/Package/ExportPackage',
-            headers={'Authorization': 'Basic TOKEN'},
-            data={'TopologyNames': ['topology_name']},
+            headers={'Authorization': 'Basic TOKEN',
+                     'Content-type': 'application/json'},
+            json={'TopologyNames': ['topology_name']},
         )
         self.assertEqual(response, 'zip package content')
 


### PR DESCRIPTION
It looks like there was a change in 9.3 that broke this method.\